### PR TITLE
fixed ChatApi::sendFile (GET => POST)

### DIFF
--- a/chatapi.class.php
+++ b/chatapi.class.php
@@ -276,7 +276,7 @@
          */
         public function sendFile($chat, $body, $filename)
         {
-            return json_decode($this->query('sendFile', ['chatId' => $chat, 'filename' => $filename, 'body' => $body], "POST"), 1)['sent'];
+            return json_decode($this->query('sendFile', ['chatId' => $chat, 'filename' => $filename, 'body' => $body], 'POST'), 1)['sent'];
         }
 
         /**


### PR DESCRIPTION
When sending large files with a GET request, an error occurs with the file_get_contents function:
Warning: file_get_contents(https://api.chat-api.com/instanceN//sendFile?chatId=M%40c.us&... in chatapi.class.php on line 67
GET => POST - and no problem :)
